### PR TITLE
Save state when todo done state is toggled

### DIFF
--- a/01 - Your First React Application/todo/src/App.js
+++ b/01 - Your First React Application/todo/src/App.js
@@ -22,17 +22,19 @@ export default class App extends Component {
         this.setState({ newItemText: event.target.value });
     }
 
+    saveState = () => localStorage.setItem("todos", JSON.stringify(this.state))
+
     createNewTodo = (task) => {
         if (!this.state.todoItems.find(item => item.action === task)) {
             this.setState({ 
                 todoItems: [...this.state.todoItems, { action: task, done: false }]
-            }, () => localStorage.setItem("todos", JSON.stringify(this.state)));        
+            }, this.saveState);
         }
     }
 
     toggleTodo = (todo) => this.setState({ todoItems: 
         this.state.todoItems.map(item => item.action === todo.action 
-            ? { ...item, done: !item.done } : item) });
+            ? { ...item, done: !item.done } : item) }, this.saveState);
     
     todoTableRows = (doneValue) => this.state.todoItems
         .filter(item => item.done === doneValue).map(item => 


### PR DESCRIPTION
The Todo app example in Chapter 1 only saves the state to local storage when an item is added, but not when the done status is toggled. For example, if you check-off all your todo items and then return to the app, you have to do them all over again. This PR fixes that.